### PR TITLE
Create Oil Panic tribute HTML game

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Oil Panic - Game &amp; Watch Tribute</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <main class="cabinet">
+      <section class="top-screen">
+        <div class="scoreboard">
+          <div class="score">SCORE <span id="score">0000</span></div>
+          <div class="misses">MISS <span id="misses">0</span></div>
+          <div class="oil-level">
+            OIL
+            <div class="slots">
+              <span class="slot" data-index="0"></span>
+              <span class="slot" data-index="1"></span>
+              <span class="slot" data-index="2"></span>
+            </div>
+          </div>
+        </div>
+        <div class="pipes">
+          <div class="pipe" data-column="0"></div>
+          <div class="pipe" data-column="1"></div>
+          <div class="pipe" data-column="2"></div>
+        </div>
+        <div id="drops" class="drop-layer"></div>
+        <div id="bucket" class="bucket" aria-live="polite">
+          <div class="bucket-top"></div>
+          <div class="bucket-body">
+            <span class="cell" data-index="0"></span>
+            <span class="cell" data-index="1"></span>
+            <span class="cell" data-index="2"></span>
+          </div>
+        </div>
+      </section>
+      <section class="hinge">
+        <div class="hinge-inner"></div>
+      </section>
+      <section class="bottom-screen">
+        <div class="floor"></div>
+        <div class="counter"></div>
+        <div class="characters">
+          <div class="friendly-wrapper">
+            <div class="friendly" id="friendly">🐱</div>
+          </div>
+          <div class="policeman" id="policeman">
+            <div class="hat"></div>
+            <div class="body"></div>
+          </div>
+        </div>
+        <div class="instructions">
+          <h1>Oil Panic Tribute</h1>
+          <p>
+            Catch the dripping oil with your bucket. Empty it over the cat when it
+            is waiting and avoid dousing the patrol! Each successful delivery is
+            worth 10 points.
+          </p>
+          <ul>
+            <li><strong>← / →</strong> – move between the three catch points</li>
+            <li><strong>Space</strong> – empty the bucket</li>
+            <li><strong>Enter</strong> – start or restart</li>
+          </ul>
+        </div>
+      </section>
+      <div class="overlay" id="overlay">
+        <div class="overlay-content">
+          <h2>Press Enter to Start</h2>
+          <p>Catch oil, deliver safely, and aim for the high score!</p>
+        </div>
+      </div>
+    </main>
+    <script src="script.js" defer></script>
+  </body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,367 @@
+const columnRatios = [0.22, 0.5, 0.78];
+const bucketOffsets = [-0.28, 0, 0.28];
+const sideOffsets = [-0.32, 0.32];
+
+const DROP_SPEED = 160; // px per second baseline
+const DROP_ACCELERATION = 8; // increases slightly with score
+const MAX_LIVES = 3;
+const SCORE_PER_DELIVERY = 10;
+
+const state = {
+  running: false,
+  drops: [],
+  lastSpawn: 0,
+  spawnDelay: 1200,
+  bucketIndex: 1,
+  bucketFill: 0,
+  lives: MAX_LIVES,
+  score: 0,
+  policemanIndex: 0,
+  policemanTimer: 0,
+  policemanDelay: 2600,
+  friendlyIndex: 0,
+  friendlyTimer: 0,
+  friendlyDelay: 4200,
+  lastFrameTime: 0,
+};
+
+const ui = {};
+
+function queryUI() {
+  ui.topScreen = document.querySelector('.top-screen');
+  ui.bottomScreen = document.querySelector('.bottom-screen');
+  ui.dropLayer = document.getElementById('drops');
+  ui.bucket = document.getElementById('bucket');
+  ui.bucketCells = ui.bucket.querySelectorAll('.cell');
+  ui.bucketSlots = document.querySelectorAll('.slot');
+  ui.score = document.getElementById('score');
+  ui.misses = document.getElementById('misses');
+  ui.overlay = document.getElementById('overlay');
+  ui.overlayTitle = ui.overlay.querySelector('h2');
+  ui.overlayText = ui.overlay.querySelector('p');
+  ui.policeman = document.getElementById('policeman');
+  ui.friendlyWrapper = document.querySelector('.friendly-wrapper');
+}
+
+const metrics = {
+  columnXs: [0, 0, 0],
+  bucketOffsetsPx: [0, 0, 0],
+  catchLine: 0,
+  sidePositions: [0, 0],
+};
+
+function recalcMetrics() {
+  const width = ui.topScreen.clientWidth;
+  const height = ui.topScreen.clientHeight;
+  metrics.columnXs = columnRatios.map((ratio) => ratio * width);
+  metrics.bucketOffsetsPx = bucketOffsets.map((ratio) => ratio * width);
+  metrics.catchLine = height - 140;
+
+  const bottomWidth = ui.bottomScreen.clientWidth;
+  metrics.sidePositions = sideOffsets.map((ratio) => ratio * bottomWidth);
+  applyBucketTransform();
+  updatePolicemanPosition();
+  updateFriendlyPosition();
+  ui.dropLayer.querySelectorAll('.drop').forEach((node) => {
+    const idx = Number(node.dataset.column);
+    if (Number.isFinite(idx)) {
+      node.style.left = `${metrics.columnXs[idx]}px`;
+    }
+  });
+}
+
+function applyBucketTransform() {
+  ui.bucket.style.setProperty(
+    '--bucket-offset',
+    `${metrics.bucketOffsetsPx[state.bucketIndex] || 0}px`
+  );
+}
+
+function updateBucketCells() {
+  ui.bucketCells.forEach((cell, index) => {
+    cell.classList.toggle('fill', index < state.bucketFill);
+  });
+  ui.bucketSlots.forEach((slot, index) => {
+    slot.classList.toggle('fill', index < state.bucketFill);
+  });
+}
+
+function updateScoreboard() {
+  ui.score.textContent = state.score.toString().padStart(4, '0');
+  ui.misses.textContent = (MAX_LIVES - state.lives).toString();
+}
+
+function clearDrops() {
+  state.drops.forEach((drop) => drop.node.remove());
+  state.drops = [];
+  ui.dropLayer.innerHTML = '';
+}
+
+function resetState() {
+  state.running = true;
+  state.drops = [];
+  state.lastSpawn = 0;
+  state.spawnDelay = 1200;
+  state.bucketIndex = 1;
+  state.bucketFill = 0;
+  state.lives = MAX_LIVES;
+  state.score = 0;
+  state.policemanIndex = 0;
+  state.policemanTimer = 0;
+  state.policemanDelay = 2600;
+  state.friendlyIndex = 0;
+  state.friendlyTimer = 0;
+  state.friendlyDelay = 4200;
+  state.lastFrameTime = performance.now();
+  clearDrops();
+  applyBucketTransform();
+  updateBucketCells();
+  updateScoreboard();
+  updatePolicemanPosition();
+  updateFriendlyPosition();
+}
+
+function spawnDrop(timestamp) {
+  const column = Math.floor(Math.random() * columnRatios.length);
+  const node = document.createElement('div');
+  node.className = 'drop';
+  node.dataset.column = column;
+  node.style.left = `${metrics.columnXs[column]}px`;
+  node.style.top = '90px';
+  ui.dropLayer.appendChild(node);
+  state.drops.push({
+    column,
+    y: 90,
+    speed: DROP_SPEED + DROP_ACCELERATION * (state.score / 10),
+    node,
+  });
+  state.lastSpawn = timestamp;
+  const speedFactor = Math.min(state.score / 200, 0.45);
+  state.spawnDelay = 1200 - 600 * speedFactor;
+}
+
+function removeDrop(index) {
+  const drop = state.drops[index];
+  if (!drop) return;
+  drop.node.remove();
+  state.drops.splice(index, 1);
+}
+
+function registerMiss() {
+  if (state.lives <= 0) return;
+  state.lives -= 1;
+  updateScoreboard();
+  sounds.spill();
+  if (state.lives <= 0) {
+    endGame();
+  }
+}
+
+function deliverOil(side) {
+  if (state.bucketFill === 0) return;
+  const policemanSide = state.policemanIndex;
+  const friendlySide = state.friendlyIndex;
+  if (policemanSide === side) {
+    registerMiss();
+  } else if (friendlySide === side) {
+    state.score += SCORE_PER_DELIVERY * state.bucketFill;
+    state.bucketFill = 0;
+    updateScoreboard();
+    sounds.deliver();
+    shuffleFriendly();
+  } else {
+    registerMiss();
+  }
+  state.bucketFill = 0;
+  updateBucketCells();
+}
+
+function shuffleFriendly() {
+  const next = Math.random() > 0.5 ? 1 : 0;
+  state.friendlyIndex = next;
+  updateFriendlyPosition();
+}
+
+function updatePolicemanPosition() {
+  const offset = metrics.sidePositions[state.policemanIndex] || 0;
+  ui.policeman.style.transform = `translateX(${offset}px)`;
+}
+
+function updateFriendlyPosition() {
+  const offset = metrics.sidePositions[state.friendlyIndex] || 0;
+  ui.friendlyWrapper.style.transform = `translateX(${offset}px)`;
+}
+
+function handleKeyDown(event) {
+  if (event.repeat) return;
+  if (event.code === 'Enter') {
+    if (!state.running) {
+      ui.overlay.classList.add('hidden');
+      resetState();
+      requestAnimationFrame(loop);
+    }
+    sounds.unlock();
+    return;
+  }
+  if (!state.running) return;
+  if (event.code === 'ArrowLeft') {
+    moveBucket(-1);
+  } else if (event.code === 'ArrowRight') {
+    moveBucket(1);
+  } else if (event.code === 'Space') {
+    emptyBucket();
+  }
+  sounds.unlock();
+}
+
+function moveBucket(direction) {
+  const next = state.bucketIndex + direction;
+  if (next < 0 || next >= bucketOffsets.length) return;
+  state.bucketIndex = next;
+  applyBucketTransform();
+  sounds.move();
+}
+
+function emptyBucket() {
+  if (state.bucketIndex === 1) {
+    sounds.denied();
+    return;
+  }
+  const side = state.bucketIndex === 0 ? 0 : 1;
+  deliverOil(side);
+}
+
+function endGame() {
+  state.running = false;
+  ui.overlay.classList.remove('hidden');
+  ui.overlayTitle.textContent = 'Game Over';
+  ui.overlayText.textContent = `Final score ${state.score.toString().padStart(4, '0')}. Press Enter to play again.`;
+  sounds.gameOver();
+}
+
+function updateDrops(delta, timestamp) {
+  for (let i = state.drops.length - 1; i >= 0; i -= 1) {
+    const drop = state.drops[i];
+    drop.y += drop.speed * delta;
+    drop.node.style.top = `${drop.y}px`;
+
+    const bucketCenter = ui.topScreen.clientWidth / 2 + metrics.bucketOffsetsPx[state.bucketIndex];
+    const dropX = metrics.columnXs[drop.column];
+    const distance = Math.abs(dropX - bucketCenter);
+
+    if (drop.y >= metrics.catchLine) {
+      if (distance < 60 && state.bucketFill < 3) {
+        state.bucketFill += 1;
+        updateBucketCells();
+        removeDrop(i);
+        sounds.catch();
+        continue;
+      }
+    }
+
+    if (drop.y > ui.topScreen.clientHeight - 40) {
+      removeDrop(i);
+      registerMiss();
+    }
+  }
+
+  if (timestamp - state.lastSpawn > state.spawnDelay) {
+    spawnDrop(timestamp);
+  }
+}
+
+function updateCharacters(delta) {
+  state.policemanTimer += delta * 1000;
+  if (state.policemanTimer >= state.policemanDelay) {
+    state.policemanIndex = state.policemanIndex === 0 ? 1 : 0;
+    state.policemanTimer = 0;
+    state.policemanDelay = 2200 + Math.random() * 1200;
+    updatePolicemanPosition();
+  }
+
+  state.friendlyTimer += delta * 1000;
+  if (state.friendlyTimer >= state.friendlyDelay) {
+    state.friendlyTimer = 0;
+    state.friendlyDelay = 3000 + Math.random() * 2200;
+    shuffleFriendly();
+  }
+}
+
+function loop(timestamp) {
+  if (!state.running) return;
+  const delta = (timestamp - state.lastFrameTime) / 1000;
+  state.lastFrameTime = timestamp;
+  updateDrops(delta, timestamp);
+  updateCharacters(delta);
+  requestAnimationFrame(loop);
+}
+
+const sounds = (() => {
+  const AudioContextClass = window.AudioContext || window.webkitAudioContext;
+  let ctx = null;
+  function ensureContext() {
+    if (!AudioContextClass) return null;
+    if (!ctx) {
+      ctx = new AudioContextClass();
+    }
+    if (ctx.state === 'suspended') {
+      ctx.resume();
+    }
+    return ctx;
+  }
+
+  function playTone(freq, duration, type = 'square', gainValue = 0.15) {
+    const audioCtx = ensureContext();
+    if (!audioCtx) return;
+    const now = audioCtx.currentTime;
+    const osc = audioCtx.createOscillator();
+    const gain = audioCtx.createGain();
+    osc.type = type;
+    osc.frequency.value = freq;
+    gain.gain.setValueAtTime(gainValue, now);
+    gain.gain.exponentialRampToValueAtTime(0.0001, now + duration);
+    osc.connect(gain).connect(audioCtx.destination);
+    osc.start(now);
+    osc.stop(now + duration + 0.05);
+  }
+
+  return {
+    unlock() {
+      ensureContext();
+    },
+    catch() {
+      playTone(980, 0.08, 'triangle', 0.18);
+    },
+    spill() {
+      playTone(220, 0.3, 'sawtooth', 0.2);
+    },
+    deliver() {
+      playTone(640, 0.2, 'square', 0.18);
+      setTimeout(() => playTone(860, 0.2, 'square', 0.16), 80);
+    },
+    move() {
+      playTone(420, 0.06, 'square', 0.1);
+    },
+    denied() {
+      playTone(120, 0.12, 'triangle', 0.12);
+    },
+    gameOver() {
+      playTone(180, 0.4, 'sawtooth', 0.18);
+      setTimeout(() => playTone(120, 0.4, 'sawtooth', 0.18), 200);
+    },
+  };
+})();
+
+function init() {
+  queryUI();
+  recalcMetrics();
+  updateBucketCells();
+  updateScoreboard();
+  window.addEventListener('resize', recalcMetrics);
+  document.addEventListener('keydown', handleKeyDown);
+  document.addEventListener('pointerdown', sounds.unlock, { once: true });
+  document.addEventListener('touchstart', sounds.unlock, { once: true });
+  ui.overlay.classList.remove('hidden');
+}
+
+document.addEventListener('DOMContentLoaded', init);

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,424 @@
+:root {
+  color-scheme: dark;
+  --cabinet-bg: #d4c6a8;
+  --screen-bg-top: #1a2134;
+  --screen-bg-bottom: #202e44;
+  --trim: #a08a5b;
+  --highlight: #f0e7c2;
+  --shadow: rgba(0, 0, 0, 0.3);
+  --bucket: #f5f1e6;
+  --oil: #1a1a1a;
+  --police: #1a3c78;
+  --friendly: #f6d365;
+  --text: #0c161f;
+  font-family: "Press Start 2P", system-ui, sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: radial-gradient(circle at top, #4f6ea9, #0f172a);
+  color: var(--text);
+}
+
+.cabinet {
+  width: min(900px, 95vw);
+  background: var(--cabinet-bg);
+  border-radius: 20px;
+  box-shadow: 0 24px 50px rgba(0, 0, 0, 0.3), inset 0 4px 0 var(--highlight);
+  padding: 18px;
+  display: grid;
+  gap: 14px;
+}
+
+.top-screen,
+.bottom-screen {
+  position: relative;
+  border-radius: 16px;
+  background: linear-gradient(180deg, #0f1523 0%, var(--screen-bg-top) 40%,
+      var(--screen-bg-bottom) 100%);
+  overflow: hidden;
+  border: 6px solid var(--trim);
+  box-shadow: inset 0 4px 10px var(--shadow);
+  height: 320px;
+}
+
+.top-screen {
+  background: linear-gradient(180deg, #121b2d 0%, #0c101c 45%, #151d2c 100%);
+}
+
+.bottom-screen {
+  background: linear-gradient(180deg, #212b3d 0%, #151d26 55%, #1d2536 100%);
+}
+
+.hinge {
+  height: 40px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.hinge-inner {
+  width: 82%;
+  height: 100%;
+  border-radius: 999px;
+  background: linear-gradient(90deg, #c3b293 0%, #eadfc6 50%, #b29b74 100%);
+  box-shadow: inset 0 0 8px rgba(0, 0, 0, 0.25);
+}
+
+.scoreboard {
+  position: absolute;
+  top: 18px;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  align-items: center;
+  gap: 18px;
+  color: #f7f0d0;
+  font-size: 12px;
+  text-shadow: 0 2px 4px rgba(0, 0, 0, 0.4);
+}
+
+.score span,
+.misses span {
+  display: inline-block;
+  min-width: 64px;
+  text-align: right;
+}
+
+.oil-level {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.slots {
+  display: flex;
+  gap: 4px;
+}
+
+.slot {
+  display: inline-block;
+  width: 14px;
+  height: 22px;
+  border: 2px solid #f6edd0;
+  border-radius: 4px;
+  background: rgba(0, 0, 0, 0.15);
+  position: relative;
+}
+
+.slot.fill::after {
+  content: "";
+  position: absolute;
+  inset: 3px 3px 3px 3px;
+  border-radius: 2px;
+  background: var(--oil);
+}
+
+.pipes {
+  position: absolute;
+  top: 70px;
+  left: 0;
+  right: 0;
+  display: flex;
+  justify-content: space-around;
+  padding: 0 50px;
+}
+
+.pipe {
+  width: 60px;
+  height: 30px;
+  background: linear-gradient(180deg, #7f8c9b, #4b5663);
+  border-radius: 8px 8px 16px 16px;
+  box-shadow: inset 0 4px 6px rgba(255, 255, 255, 0.35), inset 0 -3px 6px rgba(0, 0, 0, 0.35);
+  position: relative;
+}
+
+.pipe::after {
+  content: "";
+  position: absolute;
+  bottom: -30px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 20px;
+  height: 24px;
+  background: linear-gradient(180deg, #9faaba, #606a79);
+  border-radius: 0 0 6px 6px;
+}
+
+.bucket {
+  position: absolute;
+  bottom: 40px;
+  left: 50%;
+  transform: translate(calc(-50% + var(--bucket-offset, 0px)), 0);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  transition: transform 0.2s ease;
+}
+
+.bucket-top {
+  width: 140px;
+  height: 24px;
+  background: linear-gradient(180deg, #fefbf4, #bcb6aa);
+  border-radius: 12px 12px 2px 2px;
+  box-shadow: inset 0 4px 6px rgba(255, 255, 255, 0.6);
+}
+
+.bucket-body {
+  width: 140px;
+  height: 70px;
+  background: linear-gradient(180deg, #fef9ed, #b9b0a0);
+  border-radius: 0 0 12px 12px;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 6px;
+  padding: 10px;
+  position: relative;
+  box-shadow: inset 0 -4px 6px rgba(0, 0, 0, 0.3);
+}
+
+.bucket-body .cell {
+  border-radius: 8px;
+  background: rgba(0, 0, 0, 0.1);
+  position: relative;
+  overflow: hidden;
+}
+
+.bucket-body .cell.fill::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  height: 70%;
+  background: linear-gradient(180deg, #1a1a1a, #070707);
+}
+
+.drop-layer {
+  position: absolute;
+  inset: 0;
+}
+
+.drop {
+  width: 18px;
+  height: 24px;
+  background: radial-gradient(circle at 30% 30%, #444, #050505 70%);
+  border-radius: 50% 50% 55% 55%;
+  position: absolute;
+  transform: translate(-50%, -50%);
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.4);
+}
+
+.bottom-screen .floor {
+  position: absolute;
+  bottom: 50px;
+  left: 0;
+  right: 0;
+  height: 20px;
+  background: linear-gradient(180deg, #1d1f2a, #0c1018);
+}
+
+.bottom-screen .counter {
+  position: absolute;
+  bottom: 70px;
+  left: 50%;
+  width: 70%;
+  height: 20px;
+  transform: translateX(-50%);
+  background: linear-gradient(180deg, #b48a58, #7a5434);
+  border-radius: 10px;
+  box-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.45);
+}
+
+.characters {
+  position: absolute;
+  bottom: 90px;
+  width: 100%;
+  display: flex;
+  justify-content: space-around;
+  align-items: flex-end;
+  padding: 0 40px;
+  font-size: 48px;
+}
+
+.friendly-wrapper {
+  width: 80px;
+  height: 120px;
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+  transition: transform 0.4s ease;
+}
+
+.friendly {
+  color: var(--friendly);
+  filter: drop-shadow(0 4px 4px rgba(0, 0, 0, 0.45));
+  transform-origin: bottom center;
+  animation: friendly-bounce 1.4s ease-in-out infinite;
+}
+
+@keyframes friendly-bounce {
+  0%,
+  100% {
+    transform: translateY(0);
+  }
+  50% {
+    transform: translateY(-6px);
+  }
+}
+
+.policeman {
+  position: relative;
+  width: 80px;
+  height: 120px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  transition: transform 0.4s ease;
+}
+
+.policeman .hat {
+  width: 60px;
+  height: 28px;
+  background: linear-gradient(180deg, #234c92, #0e2c62);
+  border-radius: 12px 12px 4px 4px;
+  position: relative;
+}
+
+.policeman .hat::after {
+  content: "";
+  position: absolute;
+  bottom: -8px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 70px;
+  height: 12px;
+  background: linear-gradient(180deg, #0d1c38, #080f21);
+  border-radius: 6px;
+}
+
+.policeman .body {
+  width: 54px;
+  height: 70px;
+  background: linear-gradient(180deg, #264b87, #15294a);
+  border-radius: 14px 14px 10px 10px;
+  position: relative;
+  box-shadow: inset 0 -3px 5px rgba(0, 0, 0, 0.4);
+}
+
+.policeman .body::before,
+.policeman .body::after {
+  content: "";
+  position: absolute;
+  top: 20px;
+  width: 14px;
+  height: 50px;
+  background: linear-gradient(180deg, #264b87, #15294a);
+  border-radius: 10px;
+}
+
+.policeman .body::before {
+  left: -16px;
+}
+
+.policeman .body::after {
+  right: -16px;
+}
+
+.instructions {
+  position: absolute;
+  top: 40px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: min(480px, 90%);
+  text-align: center;
+  color: #f5ebce;
+  font-size: 12px;
+  text-shadow: 0 2px 6px rgba(0, 0, 0, 0.6);
+  line-height: 1.5;
+}
+
+.instructions h1 {
+  font-size: 20px;
+  margin-bottom: 14px;
+}
+
+.instructions ul {
+  margin-top: 10px;
+  list-style: none;
+  display: grid;
+  gap: 6px;
+}
+
+.overlay {
+  position: absolute;
+  inset: 18px;
+  background: rgba(14, 20, 32, 0.85);
+  border-radius: 16px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #f7f2d3;
+  text-align: center;
+  backdrop-filter: blur(6px);
+  transition: opacity 0.4s ease;
+}
+
+.overlay.hidden {
+  opacity: 0;
+  pointer-events: none;
+}
+
+.overlay-content h2 {
+  font-size: 24px;
+  margin-bottom: 16px;
+}
+
+.overlay-content p {
+  font-size: 12px;
+  line-height: 1.6;
+}
+
+@media (max-width: 680px) {
+  .cabinet {
+    padding: 12px;
+    border-radius: 16px;
+  }
+
+  .top-screen,
+  .bottom-screen {
+    height: 260px;
+  }
+
+  .bucket-top,
+  .bucket-body {
+    width: 100px;
+  }
+
+  .bucket-body {
+    height: 56px;
+    padding: 8px;
+  }
+
+  .bucket {
+    bottom: 30px;
+  }
+
+  .pipe {
+    width: 44px;
+  }
+
+  .instructions {
+    font-size: 10px;
+  }
+}


### PR DESCRIPTION
## Summary
- add an index page with dual-screen layout, scoreboard, and instructions for an Oil Panic tribute
- style the cabinet, sprites, and animations to emulate the Game & Watch aesthetic while remaining responsive
- implement JavaScript game logic for smooth oil drop handling, scoring, character movement, and retro-inspired audio cues

## Testing
- python3 -m http.server 8000 (manual verification)


------
https://chatgpt.com/codex/tasks/task_e_68f11a12931483298339130eb411caeb